### PR TITLE
adds emoji in invalid label

### DIFF
--- a/pull_request.js
+++ b/pull_request.js
@@ -70,7 +70,7 @@ const pullRequestHandler = (octokit) => {
       }
 
       // pr has an invalid label and closed, reply with novalue comment
-      if (!merged && hasLabel(labels, 'invalid')) {
+      if (!merged && hasLabel(labels, 'invalid 🚫')) {
         console.log(`pr is closed with invalid label, send a bitter sorry`);
         message = prNovalue(login);
       }


### PR DESCRIPTION
Noticed that the message for "invalid" label was not showing up correctly, as the label seem to have modified in the graphl-engine repo to have an emoji :smile: 

Verified this bug via https://github.com/hasura/graphql-engine/pull/6266