### PR TITLE
deletes review apps automatically when a PR is closed

### DIFF
--- a/github_action.js
+++ b/github_action.js
@@ -1,0 +1,17 @@
+export function monoRepoWorkflowDispatch(octokit, name) {
+  return async (inputs) => {
+    try {
+      console.log(`dispatching github workflow: ${name}`);
+      await octokit.actions.createWorkflowDispatch({
+        owner: 'hasura',
+        repo: 'graphql-engine-mono',
+        workflow_id: `${name}.yml`,
+        ref: 'main',
+        inputs,
+      });
+    } catch (e) {
+      console.error(`failed to dispatch github workflow: ${name}`);
+      console.error(e);
+    }
+  };
+}

--- a/pull_request.js
+++ b/pull_request.js
@@ -2,40 +2,47 @@
 
 import { prOpened, prClosed, prNovalue, prMerged } from './messages';
 
-async function shadowOssPr(octokit, ossPrNumber) {
-  try {
-    console.log('dispatching github workflow: migrate-hge-pr');
-    let shadowPr = await octokit.actions.createWorkflowDispatch({
-      owner: 'hasura',
-      repo: 'graphql-engine-mono',
-      workflow_id: 'migrate-hge-pr.yml',
-      ref: 'main',
-      inputs: {
-        ossPrNumber: `${ossPrNumber}`
-      },
-    });
-  } catch (e) {
-    console.error('failed to dispatch github workflow: migrate-hge-pr');
-    console.error(e);
-  }
+function monoRepoWorkflowDispatch(octokit, name) {
+  return async (inputs) => {
+    try {
+      console.log(`dispatching github workflow: ${name}`);
+      await octokit.actions.createWorkflowDispatch({
+        owner: 'hasura',
+        repo: 'graphql-engine-mono',
+        workflow_id: `${name}.yml`,
+        ref: 'main',
+        inputs,
+      });
+    } catch (e) {
+      console.error(`failed to dispatch github workflow: ${name}`);
+      console.error(e);
+    }
+  };
 }
 
 const pullRequestHandler = (octokit) => {
+  const shadowOssPr = monoRepoWorkflowDispatch(octokit, 'migrate-hge-pr');
+  const deleteReviewApp = monoRepoWorkflowDispatch(octokit, 'delete-review-app');
+
   return async ({ id, name, payload }) => {
 
     console.log(`received pull request event: ${id}`);
 
     // extract relevant information
     const {action, number, repository, sender} = payload;
-    const {pull_request: {merged, body, labels, user: {login}}} = payload;
+    const {pull_request: {html_url: prLink, merged, body, labels, user: {login}}} = payload;
 
     if ((action === 'opened') || (action === 'synchronize')) {
       // There could be PRs which are shadowed from monorepo to oss repo
       // via devbot. Such PRs are identified by a `<!-- mono -->` prefix.
       // Shadowing such PRs is essential to avoid cyclic shadowing.
       if (!body.startsWith('<!-- from mono -->')) {
-        await shadowOssPr(octokit, number);
+        await shadowOssPr({ossPrNumber: `${number}`});
       }
+    }
+
+    if (action === 'closed') {
+      await deleteReviewApp(octokit, 'delete-review-app', {prLink});
     }
 
     let isHasuraOrgMember = false;

--- a/pull_request.js
+++ b/pull_request.js
@@ -1,24 +1,7 @@
 // pull_request.js: all PR related handlers
 
 import { prOpened, prClosed, prNovalue, prMerged } from './messages';
-
-function monoRepoWorkflowDispatch(octokit, name) {
-  return async (inputs) => {
-    try {
-      console.log(`dispatching github workflow: ${name}`);
-      await octokit.actions.createWorkflowDispatch({
-        owner: 'hasura',
-        repo: 'graphql-engine-mono',
-        workflow_id: `${name}.yml`,
-        ref: 'main',
-        inputs,
-      });
-    } catch (e) {
-      console.error(`failed to dispatch github workflow: ${name}`);
-      console.error(e);
-    }
-  };
-}
+import { monoRepoWorkflowDispatch } from './github_action';
 
 const pullRequestHandler = (octokit) => {
   const shadowOssPr = monoRepoWorkflowDispatch(octokit, 'migrate-hge-pr');

--- a/pull_request.js
+++ b/pull_request.js
@@ -16,7 +16,7 @@ const pullRequestHandler = (octokit) => {
     const {pull_request: {html_url: prLink, merged, body, labels, user: {login}}} = payload;
 
     if (action === 'closed') {
-      await deleteReviewApp(octokit, 'delete-review-app', {prLink});
+      await deleteReviewApp({prLink});
     }
 
     if (repository.name !== 'graphql-engine') {


### PR DESCRIPTION
https://github.com/hasura/graphql-engine-mono/issues/389

Whenever a PR is closed/merged in the graphql-engine repo, the GitHub action workflow for deleting the respective review app will get triggered.